### PR TITLE
Resolve 'Enable strict checking of objc_msgSend Calls' LLVM warning.

### DIFF
--- a/GSFancyText/src/GSFancyText.m
+++ b/GSFancyText/src/GSFancyText.m
@@ -1173,7 +1173,7 @@ typedef enum {
     else {
         SEL sel = NSSelectorFromString([NSString stringWithFormat:@"%@Color", value]);
         if ([[UIColor class] respondsToSelector: sel]) {
-            color = objc_msgSend([UIColor class], sel);
+            color = ((UIColor* (*)(Class, SEL))objc_msgSend)([UIColor class], sel);
         }
     }
     


### PR DESCRIPTION
Updating to CocoaPods > 0.36.x enables the 'Enable strict checking of objc_msgSend Calls' flag, which throws an error when trying to call objc_msgSend without casting it correctly first.

See related:
http://stackoverflow.com/questions/24922913/too-many-arguments-to-function-call-expected-0-have-3
http://stackoverflow.com/questions/25852079/in-xcode6-gold-master-using-objc-msgsend-now-throws-a-syntax-error-saying-the-n
https://github.com/th-in-gs/THObserversAndBinders/blob/master/THObserversAndBinders/THObserver.m